### PR TITLE
Added support for Breaking and Entering as a crime

### DIFF
--- a/Assets/Scripts/Game/PlayerActivate.cs
+++ b/Assets/Scripts/Game/PlayerActivate.cs
@@ -949,6 +949,7 @@ namespace DaggerfallWorkshop.Game
                 if (Dice100.SuccessRoll(chance))
                 {
                     // Success - player has forced their way into building
+                    playerEntity.CrimeCommitted = PlayerEntity.Crimes.Breaking_And_Entering;
                     playerEntity.TallyCrimeGuildRequirements(true, 1);
                     TransitionInterior(doorOwner, door, true);
                     return true;


### PR DESCRIPTION
Currently, only "Attempted Breaking and Entering" is supported. This upgrades the seriousness of the crime if you successfully enter the location.